### PR TITLE
Rename remote_ip into ip

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,7 @@ It is intended to collect user request log, action log and any other custome log
       "HTTP_COOKIE": "xxx"
     },
     "status_code": 200,
-    "remote_ip": "127.0.0.1",
+    "ip": "127.0.0.1",
     "user_agent": "Mozilla/5.0 (Macintosh; Intel Mac OS X 10_11_6) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/54.0.2840.98 Safari/537.36",
     "device": "pc",
     "os": "Mac OSX",

--- a/lib/rack/action_logger/metrics/rack_metrics.rb
+++ b/lib/rack/action_logger/metrics/rack_metrics.rb
@@ -5,7 +5,7 @@ require 'woothee'
 module Rack::ActionLogger::Metrics
   class RackMetrics
     METRICS = [
-      :path, :method, :params, :request_headers, :status_code, :remote_ip, :user_agent, :device, :os, :browser,
+      :path, :method, :params, :request_headers, :status_code, :ip, :user_agent, :device, :os, :browser,
       :browser_version, :request_id, :response_headers, :response_json_body,
     ]
     RACK_TAG_PREFIX = 'rack'
@@ -70,7 +70,7 @@ module Rack::ActionLogger::Metrics
       @response.content_type
     end
 
-    def remote_ip
+    def ip
       @request.ip
     end
 

--- a/spec/rack/action_logger/metrics/rack_metrics_spec.rb
+++ b/spec/rack/action_logger/metrics/rack_metrics_spec.rb
@@ -81,7 +81,7 @@ RSpec.describe Rack::ActionLogger::Metrics::RackMetrics do
 
   describe 'remote_ip' do
     it do
-      expect(target.remote_ip).to eq ip
+      expect(target.ip).to eq ip
     end
   end
 


### PR DESCRIPTION
remote_ip method returns `request.ip`.
It confused me.