### PR TITLE
Fix deprecated methods. `attribute_changed?` and `attribute_was`

### DIFF
--- a/lib/rack/action_logger/active_record_extension.rb
+++ b/lib/rack/action_logger/active_record_extension.rb
@@ -25,9 +25,9 @@ module Rack::ActionLogger
       self.class.column_names.each do |column_name|
         if column_name.end_with?('_id')
           record["_#{column_name}"] = self.try(column_name)
-        elsif self.try("#{column_name}_changed?")
+        elsif self.try("saved_change_to_#{column_name}?")
           record["_after:#{column_name}"] = self.try(column_name)
-          record["_before:#{column_name}"] = self.try("#{column_name}_was")
+          record["_before:#{column_name}"] = self.try("#{column_name}_before_last_save")
         end
       end
       record = Rack::ActionLogger::ParameterFiltering.apply_filter(record)


### PR DESCRIPTION
Rails 5.1 deprecate `attribute_changed?` and `attribute_was`.
https://github.com/rails/rails/pull/25337

If this PR merged, rack-action_logger requires Rails 5.1.
